### PR TITLE
Allow setting stack values in analysis frames

### DIFF
--- a/asm-analysis/src/main/java/org/objectweb/asm/tree/analysis/Frame.java
+++ b/asm-analysis/src/main/java/org/objectweb/asm/tree/analysis/Frame.java
@@ -179,6 +179,20 @@ public class Frame<V extends Value> {
     return values[nLocals + index];
   }
 
+  /**
+   * Sets the value of the given stack slot.
+   *
+   * @param i
+   *   the index of an operand stack slot.
+   * @param value
+   *   the new value of the stack slot.
+   * @throws IndexOutOfBoundsException
+   *   if the stack slot does not exist.
+   */
+  public void setStack(final int i, final V value) throws IndexOutOfBoundsException {
+      values[i + nLocals] = value;
+  }
+
   /** Clears the operand stack of this frame. */
   public void clearStack() {
     nStack = 0;


### PR DESCRIPTION
Adds a method `setStack` to analysis.Frame which allows setting the
dataflow value of a stack slot.

Could be used in nullness analysis. After, for example, an instance call,
aliases of the receiver can be set to NotNull, both in locals and on the
stack.