### PR TITLE
Call interpreter.copyOperation consistently

### DIFF
--- a/asm-analysis/src/main/java/org/objectweb/asm/tree/analysis/Frame.java
+++ b/asm-analysis/src/main/java/org/objectweb/asm/tree/analysis/Frame.java
@@ -302,7 +302,7 @@ public class Frame<V extends Value> {
         if (value1.getSize() != 1) {
           throw new AnalyzerException(insn, "Illegal use of DUP");
         }
-        push(value1);
+        push(interpreter.copyOperation(insn, value1));
         push(interpreter.copyOperation(insn, value1));
         break;
       case Opcodes.DUP_X1:
@@ -312,8 +312,8 @@ public class Frame<V extends Value> {
           throw new AnalyzerException(insn, "Illegal use of DUP_X1");
         }
         push(interpreter.copyOperation(insn, value1));
-        push(value2);
-        push(value1);
+        push(interpreter.copyOperation(insn, value2));
+        push(interpreter.copyOperation(insn, value1));
         break;
       case Opcodes.DUP_X2:
         value1 = pop();
@@ -323,15 +323,15 @@ public class Frame<V extends Value> {
             value3 = pop();
             if (value3.getSize() == 1) {
               push(interpreter.copyOperation(insn, value1));
-              push(value3);
-              push(value2);
-              push(value1);
+              push(interpreter.copyOperation(insn, value3));
+              push(interpreter.copyOperation(insn, value2));
+              push(interpreter.copyOperation(insn, value1));
               break;
             }
           } else {
             push(interpreter.copyOperation(insn, value1));
-            push(value2);
-            push(value1);
+            push(interpreter.copyOperation(insn, value2));
+            push(interpreter.copyOperation(insn, value1));
             break;
           }
         }
@@ -341,14 +341,14 @@ public class Frame<V extends Value> {
         if (value1.getSize() == 1) {
           value2 = pop();
           if (value2.getSize() == 1) {
-            push(value2);
-            push(value1);
+            push(interpreter.copyOperation(insn, value2));
+            push(interpreter.copyOperation(insn, value1));
             push(interpreter.copyOperation(insn, value2));
             push(interpreter.copyOperation(insn, value1));
             break;
           }
         } else {
-          push(value1);
+          push(interpreter.copyOperation(insn, value1));
           push(interpreter.copyOperation(insn, value1));
           break;
         }
@@ -362,9 +362,9 @@ public class Frame<V extends Value> {
             if (value3.getSize() == 1) {
               push(interpreter.copyOperation(insn, value2));
               push(interpreter.copyOperation(insn, value1));
-              push(value3);
-              push(value2);
-              push(value1);
+              push(interpreter.copyOperation(insn, value3));
+              push(interpreter.copyOperation(insn, value2));
+              push(interpreter.copyOperation(insn, value1));
               break;
             }
           }
@@ -372,8 +372,8 @@ public class Frame<V extends Value> {
           value2 = pop();
           if (value2.getSize() == 1) {
             push(interpreter.copyOperation(insn, value1));
-            push(value2);
-            push(value1);
+            push(interpreter.copyOperation(insn, value2));
+            push(interpreter.copyOperation(insn, value1));
             break;
           }
         }
@@ -389,18 +389,18 @@ public class Frame<V extends Value> {
               if (value4.getSize() == 1) {
                 push(interpreter.copyOperation(insn, value2));
                 push(interpreter.copyOperation(insn, value1));
-                push(value4);
-                push(value3);
-                push(value2);
-                push(value1);
+                push(interpreter.copyOperation(insn, value4));
+                push(interpreter.copyOperation(insn, value3));
+                push(interpreter.copyOperation(insn, value2));
+                push(interpreter.copyOperation(insn, value1));
                 break;
               }
             } else {
               push(interpreter.copyOperation(insn, value2));
               push(interpreter.copyOperation(insn, value1));
-              push(value3);
-              push(value2);
-              push(value1);
+              push(interpreter.copyOperation(insn, value3));
+              push(interpreter.copyOperation(insn, value2));
+              push(interpreter.copyOperation(insn, value1));
               break;
             }
           }
@@ -410,15 +410,15 @@ public class Frame<V extends Value> {
             value3 = pop();
             if (value3.getSize() == 1) {
               push(interpreter.copyOperation(insn, value1));
-              push(value3);
-              push(value2);
-              push(value1);
+              push(interpreter.copyOperation(insn, value3));
+              push(interpreter.copyOperation(insn, value2));
+              push(interpreter.copyOperation(insn, value1));
               break;
             }
           } else {
             push(interpreter.copyOperation(insn, value1));
-            push(value2);
-            push(value1);
+            push(interpreter.copyOperation(insn, value2));
+            push(interpreter.copyOperation(insn, value1));
             break;
           }
         }


### PR DESCRIPTION
Before this change, `Frame.execute` did not invoke the interpreter's
`copyOperation` method for all values that are pushed on the frame's
when executing some copying instructions.

For example, in the case of `SWAP`, `copyOperation` is invoked:

    value2 = pop();
    value1 = pop();
    push(interpreter.copyOperation(insn, value2));
    push(interpreter.copyOperation(insn, value1));

For `DUP` on the other hand, the original value is pushed onto the
stack without notifying the interpreter:

    value1 = pop();
    push(value1);
    push(interpreter.copyOperation(insn, value1));

This leads to a problem for the `SourceInterpreter`, which collects
for every value a set of potential producer instructions. Given the
bytecode sequence

    NEW java/lang/Object
    DUP
    INVOKESPECIAL java/lang/Object.<init> ()V

In the frame of the `INVOKESPECIAL` instruction, the value on the stack
lists as its producer the `NEW` operation instead of the `DUP`, which
not expected.

